### PR TITLE
fix typo in nftables default ruleset

### DIFF
--- a/libraries/helpers_nftables.rb
+++ b/libraries/helpers_nftables.rb
@@ -135,7 +135,7 @@ module FirewallCookbook
           'add table inet filter' => 1,
           "add chain inet filter INPUT { type filter hook input priority 0 ; policy #{new_resource.input_policy}; }" => 2,
           "add chain inet filter OUTPUT { type filter hook output priority 0 ; policy #{new_resource.output_policy}; }" => 2,
-          "add chain inet filter FOWARD { type filter hook forward priority 0 ; policy #{new_resource.forward_policy}; }" => 2,
+          "add chain inet filter FORWARD { type filter hook forward priority 0 ; policy #{new_resource.forward_policy}; }" => 2,
         }
         if new_resource.table_ip_nat
           rules['add table ip nat'] = 1


### PR DESCRIPTION
Fixes typo in FORWARD chain of nftables default ruleset.
This causes Chef Client to fail in case FORWARD chain rule is created.